### PR TITLE
issue#204: externalGoUsernames ogs url alternative 

### DIFF
--- a/server/views/partials/user.jade
+++ b/server/views/partials/user.jade
@@ -120,7 +120,7 @@
 											a(href='https://online-go.com') OGS
 										td
 											a(
-												href='https://online-go.com/user/{{ user.externalGoUsernames.ogs}}'
+												href='https://online-go.com/player/{{ user.externalGoUsernames.ogs}}'
 											) {{ user.externalGoUsernames.ogs }}
 									tr(ng-show='user.externalGoUsernames.igs || edit')
 										th


### PR DESCRIPTION
ogs username is in the format online-go.com/player/idNumber 

add externalGoUsernames.ogsp to user schema next?

issue#204